### PR TITLE
Update libraries schema with timestamp

### DIFF
--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -10,9 +10,7 @@ class LibrariesController < ApplicationController
     library = Library.new({
       name: params[:library][:name],
       public: params[:library][:public],
-      years_opened: params[:library][:years_opened],
-      created_at: params[:library][:created_at],
-      updated_at: params[:library][:updated_at]
+      years_opened: params[:library][:years_opened]
       })
 
     library.save

--- a/db/migrate/20210203233353_remove_columns_from_libraries.rb
+++ b/db/migrate/20210203233353_remove_columns_from_libraries.rb
@@ -1,0 +1,6 @@
+class RemoveColumnsFromLibraries < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :libraries, :created_at, :datetime
+    remove_column :libraries, :updated_at, :datetime
+  end
+end

--- a/db/migrate/20210203234539_add_timestamps_to_libraries.rb
+++ b/db/migrate/20210203234539_add_timestamps_to_libraries.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToLibraries < ActiveRecord::Migration[5.2]
+  def change
+    add_timestamps :libraries
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2021_02_03_052910) do
-
-# ActiveRecord::Schema.define(version: 2021_02_03_021559) do
-
+ActiveRecord::Schema.define(version: 2021_02_03_234539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,8 +19,8 @@ ActiveRecord::Schema.define(version: 2021_02_03_052910) do
     t.string "name"
     t.boolean "public"
     t.integer "years_opened"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "locations", force: :cascade do |t|


### PR DESCRIPTION
Updated the Libraries table to now reflect timestamps instead of created_at and updated_at attributes. Ran a migration to remove those two attributes and then a migration to add the timestamps column which updated the schema after running the migration. Additionally, I removed the created_at and updated_at parameters from the create method in libraries controller.